### PR TITLE
Retry request to run notebook job if organization is not active yet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 
 .databricks
 .vscode
+.idea
 typings

--- a/src/databricks_clean_room_orchestrator/client.py
+++ b/src/databricks_clean_room_orchestrator/client.py
@@ -282,7 +282,17 @@ class CleanRoomClient:
 
     # Run the clean room notebook
     print("Setting up station notebook job run")
-    self._rest_client.setupStationResource(self._clean_room, self._station_name, Resource.NOTEBOOK_JOB_RUN)
+    while True:
+      try:
+        self._rest_client.setupStationResource(self._clean_room, self._station_name, Resource.NOTEBOOK_JOB_RUN)
+      except HTTPError as e:
+        if "has been cancelled or is not active yet" in e.strerror:
+          print("Organization is not active yet. Retrying request.")
+        else:
+          raise e
+      else:
+        break
+      time.sleep(10)
     print("Waiting for clean room notebook to finish running...")
     state = None
     while True:


### PR DESCRIPTION
I was not able to reproduce the bug, so I have made this PR for @wchau to check if this is the correct logic.

### Changes
- Created a loop to retry the request to set up the notebook job run if the "Organization has been cancelled or is not active yet" error is encountered.
- Add .idea to the gitignore

### Testing
- Tested in a staging notebook by pip installing my fork to make sure there were no breaking changes
- Haven't encountered a case where the retry was actually needed